### PR TITLE
Fix retrieve base

### DIFF
--- a/src/Pool/Modules/PoolNonTv.sol
+++ b/src/Pool/Modules/PoolNonTv.sol
@@ -71,7 +71,7 @@ contract PoolNonTv is Pool {
         // For PoolNonTv, sharesToken == baseToken. This allows for the use of the core Pool.sol contract logic with
         // non-yield-bearing tokens. As such the sharesCached state var actually represents baseTokens, since they
         // are the same.
-        retrieved = (baseToken.balanceOf(address(this)) - sharesCached).u128();
+        retrieved = (sharesToken.balanceOf(address(this)) - sharesCached).u128();
         baseToken.safeTransfer(to, retrieved);
     }
 

--- a/src/Pool/Modules/PoolNonTv.sol
+++ b/src/Pool/Modules/PoolNonTv.sol
@@ -72,7 +72,7 @@ contract PoolNonTv is Pool {
         // non-yield-bearing tokens. As such the sharesCached state var actually represents baseTokens, since they
         // are the same.
         retrieved = (sharesToken.balanceOf(address(this)) - sharesCached).u128();
-        baseToken.safeTransfer(to, retrieved);
+        sharesToken.safeTransfer(to, retrieved);
     }
 
     /// **This function is intentionally empty to overwrite the Pool._approveSharesToken fn.**

--- a/src/Pool/Pool.sol
+++ b/src/Pool/Pool.sol
@@ -1392,17 +1392,17 @@ contract Pool is PoolEvents, IPool, ERC20Permit, AccessControl {
     /// @param to Address of the recipient of the shares tokens.
     /// @return retrieved The amount of shares tokens sent.
     function retrieveShares(address to) external virtual override returns (uint128 retrieved) {
-        // related: https://twitter.com/transmissions11/status/1505994136389754880?s=20&t=1H6gvzl7DJLBxXqnhTuOVw
         retrieved = _getSharesBalance() - sharesCached; // Cache can never be above balances
         sharesToken.safeTransfer(to, retrieved);
-        // Now the current balances match the cache, so no need to update the TWAR
     }
 
     /// Retrieve all base tokens found in this contract.
     /// @param to Address of the recipient of the base tokens.
     /// @return retrieved The amount of base tokens sent.
     function retrieveBase(address to) external virtual override returns (uint128 retrieved) {
-        retrieved = baseToken.balanceOf(address(this)).u128();  // Pool does not keep any baseTokens so retrieve everything
+        // This and most other pools do not keep any baseTokens, so retrieve everything.
+        // Note: For PoolNonTv, baseToken == sharesToken so must override this fn.
+        retrieved = baseToken.balanceOf(address(this)).u128();
         baseToken.safeTransfer(to, retrieved);
     }
 

--- a/src/test/EulerVault_MintBurnTrading.t.sol
+++ b/src/test/EulerVault_MintBurnTrading.t.sol
@@ -35,6 +35,7 @@ import "./shared/Constants.sol";
 import {ETokenMock} from "./mocks/ETokenMock.sol";
 import {ZeroState, ZeroStateParams} from "./shared/ZeroState.sol";
 import {SyncablePoolEuler} from "./mocks/SyncablePoolEuler.sol";
+import {IERC20Like} from  "../interfaces/IERC20Like.sol";
 
 abstract contract ZeroStateEulerUSDC is ZeroState {
     using CastU256U128 for uint256;
@@ -508,5 +509,252 @@ contract TradeUSDC__OnceMatureEuler is OnceMature {
         pool.buyFYTokenPreview(uint128(WAD));
         vm.expectRevert(bytes("Pool: Too late"));
         pool.buyFYToken(alice, uint128(WAD), uint128(MAX));
+    }
+}
+
+contract AdminUSDC__WithLiquidityEuler is WithLiquidityEuler {
+
+    function testUnit_admin1_EulerUSDC() public {
+        console.log("retrieveBase returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveBase(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+    }
+
+    function testUnit_admin2_EulerUSDC() public {
+        console.log("retrieveBase returns exceess");
+        uint256 additionalAmount = 69;
+        IERC20Like base = IERC20Like(address(pool.baseToken()));
+        vm.prank(alice);
+        base.transfer(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveBase(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance + additionalAmount);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+    }
+
+    function testUnit_admin3_EulerUSDC() public {
+        console.log("retrieveShares returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveShares(alice);
+
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+    }
+
+    function testUnit_admin4_EulerUSDC() public {
+        console.log("retrieveShares returns exceess");
+
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+        // There is a fractional amount of excess eUSDC shares in the pool
+        // as a result of the decimals mismatch between eUSDC (18) and actual USDC (6)
+        // The amount is less than 2/10 of a wei of USDC: 0.000000181818181819 USDC
+        uint256 fractionalExcess = pool.sharesToken().balanceOf(address(pool)) - startingSharesCached * 1e12;
+        assertEq(fractionalExcess, 181818181819);
+
+        uint256 additionalAmount = 69e18;
+        shares.mint(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+
+        pool.retrieveShares(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance + additionalAmount + fractionalExcess);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+    }
+
+    function testUnit_admin5_EulerUSDC() public {
+        console.log("retrieveFYToken returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        uint256 startingFyTokenBalance = pool.fyToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveFYToken(alice);
+
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        assertEq(pool.fyToken().balanceOf(alice), startingFyTokenBalance);
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+
+    }
+
+    function testUnit_admin6_EulerUSDC() public {
+        console.log("retrieveFYToken returns exceess");
+        uint256 additionalAmount = 69e18;
+        fyToken.mint(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        uint256 startingFyTokenBalance = pool.fyToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveFYToken(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(pool.fyToken().balanceOf(alice), startingFyTokenBalance + additionalAmount);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+    }
+}
+
+abstract contract ZeroStateEulerDAI is ZeroState {
+    using CastU256U128 for uint256;
+
+    constructor() ZeroState(ZeroStateParams("DAI", "DAI", 18, "EulerVault")) {}
+}
+
+abstract contract WithLiquidityEulerDAI is ZeroStateEulerDAI {
+    function setUp() public virtual override {
+        super.setUp();
+
+        shares.mint(address(pool), INITIAL_SHARES * 10**(shares.decimals()));
+        vm.prank(alice);
+        pool.init(alice);
+        setPrice(address(shares), (cNumerator * (10**shares.decimals())) / cDenominator);
+        uint256 additionalFYToken = (INITIAL_SHARES * 10**(asset.decimals())) / 9;
+
+        fyToken.mint(address(pool), additionalFYToken);
+        pool.sellFYToken(alice, 0);
+    }
+}
+
+
+contract AdminDAI__WithLiquidityEuler is WithLiquidityEulerDAI {
+
+    function testUnit_admin1_EulerDAI() public {
+        console.log("retrieveBase returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveBase(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+    }
+
+    function testUnit_admin2_EulerDAI() public {
+        console.log("retrieveBase returns exceess");
+        uint256 additionalAmount = 69;
+        IERC20Like base = IERC20Like(address(pool.baseToken()));
+        vm.prank(alice);
+        base.transfer(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveBase(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance + additionalAmount);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+    }
+
+    function testUnit_admin3_EulerDAI() public {
+        console.log("retrieveShares returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveShares(alice);
+
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+    }
+
+    function testUnit_admin4_EulerDAI() public {
+        console.log("retrieveShares returns exceess");
+
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        uint256 additionalAmount = 69e18;
+        shares.mint(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+
+        pool.retrieveShares(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+
+        // There is a 1 wei difference attributable to some deep nested rounding
+        assertApproxEqAbs(pool.sharesToken().balanceOf(alice), startingSharesBalance + additionalAmount, 1);
+    }
+
+    function testUnit_admin5_EulerDAI() public {
+        console.log("retrieveFYToken returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        uint256 startingFyTokenBalance = pool.fyToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveFYToken(alice);
+
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        assertEq(pool.fyToken().balanceOf(alice), startingFyTokenBalance);
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+
+    }
+
+    function testUnit_admin6_EulerDAI() public {
+        console.log("retrieveFYToken returns exceess");
+        uint256 additionalAmount = 69e18;
+        fyToken.mint(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        uint256 startingFyTokenBalance = pool.fyToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveFYToken(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(pool.fyToken().balanceOf(alice), startingFyTokenBalance + additionalAmount);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
     }
 }

--- a/src/test/YearnVault_MintBurnTrading.t.sol
+++ b/src/test/YearnVault_MintBurnTrading.t.sol
@@ -34,6 +34,7 @@ import "./shared/Utils.sol";
 import "./shared/Constants.sol";
 import {YVTokenMock} from "./mocks/YVTokenMock.sol";
 import {ZeroState, ZeroStateParams} from "./shared/ZeroState.sol";
+import {IERC20Like} from  "../interfaces/IERC20Like.sol";
 
 abstract contract ZeroStateYearnDai is ZeroState {
     constructor() ZeroState(ZeroStateParams("DAI", "DAI", 18, "YearnVault")) {}
@@ -525,3 +526,113 @@ contract TradeDAI__OnceMatureYearnVault is OnceMature {
         pool.buyFYToken(alice, uint128(WAD), uint128(MAX));
     }
 }
+
+
+contract Admin__WithLiquidityYearnVault is WithLiquidityYearnVault {
+
+    function testUnit_admin1_YearnVault() public {
+        console.log("retrieveBase returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveBase(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+    }
+
+    function testUnit_admin2_YearnVault() public {
+        console.log("retrieveBase returns exceess");
+        uint256 additionalAmount = 69;
+        IERC20Like base = IERC20Like(address(pool.baseToken()));
+        vm.prank(alice);
+        base.transfer(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveBase(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance + additionalAmount);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+    }
+
+    function testUnit_admin3_YearnVault() public {
+        console.log("retrieveShares returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveShares(alice);
+
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+    }
+
+    function testUnit_admin4_YearnVault() public {
+        console.log("retrieveShares returns exceess");
+
+        uint256 additionalAmount = 69e18;
+        shares.mint(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveShares(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance + additionalAmount);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+    }
+
+    function testUnit_admin5_YearnVault() public {
+        console.log("retrieveFYToken returns nothing if there is no excess");
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        uint256 startingFyTokenBalance = pool.fyToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveFYToken(alice);
+
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        assertEq(pool.fyToken().balanceOf(alice), startingFyTokenBalance);
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+
+    }
+
+    function testUnit_admin6_YearnVault() public {
+        console.log("retrieveFYToken returns exceess");
+        uint256 additionalAmount = 69e18;
+        fyToken.mint(address(pool), additionalAmount);
+
+        uint256 startingBaseBalance = pool.baseToken().balanceOf(alice);
+        uint256 startingSharesBalance = pool.sharesToken().balanceOf(alice);
+        uint256 startingFyTokenBalance = pool.fyToken().balanceOf(alice);
+        (uint104 startingSharesCached, uint104 startingFyTokenCached,,) = pool.getCache();
+
+        pool.retrieveFYToken(alice);
+
+        (uint104 currentSharesCached, uint104 currentFyTokenCached,,) = pool.getCache();
+        assertEq(currentFyTokenCached, startingFyTokenCached);
+        assertEq(currentSharesCached, startingSharesCached);
+        assertEq(pool.fyToken().balanceOf(alice), startingFyTokenBalance + additionalAmount);
+        assertEq(pool.sharesToken().balanceOf(alice), startingSharesBalance);
+        assertEq(pool.baseToken().balanceOf(alice), startingBaseBalance);
+    }
+}
+


### PR DESCRIPTION
Fixes retrieveBase for PoolNonTv

Overrides both `retrieveBase` and `retrieveShares` and points them both at an internal `_retrieveBase()` -- Technically, we did not have to override retrieveShares, but it seemed cleaner to have them all to gether in the PoolNonTv module rather than have `retrieveBase` in the module and `retrieveShares` in the core, especially when they all do the same thing.

Added a bunch of tests:

- [x] Test `retrieveBase()` with excess, and no excess for PoolNonTv.sol   (_Note:_ for these tests, also commented out the changes to PoolNonTv and watched them fail.)
- [x] Test `retrieveShares()` with excess, and no excess for PoolNonTv.sol
- [x] Test `retrieveFYToken()` with excess, and no excess for PoolNonTv.sol
- [x] Test `retrieveBase()` with excess, and no excess for Pool.sol
- [x] Test `retrieveShares()` with excess, and no excess for Pool.sol
- [x] Test `retrieveFYToken()` with excess, and no excess for Pool.sol
- [x] Test `retrieveBase()` with excess, and no excess for PoolEuler.sol with eUSDC
- [x] Test `retrieveShares()` with excess, and no excess for PoolEuler.sol with eUSDC
- [x] Test `retrieveFYToken()` with excess, and no excess for PoolEuler.sol with eUSDC
- [x] Test `retrieveBase()` with excess, and no excess for PoolEuler.sol with eDAI
- [x] Test `retrieveShares()` with excess, and no excess for PoolEuler.sol with eDAI
- [x] Test `retrieveFYToken()` with excess, and no excess for PoolEuler.sol with eDAI
- [x] Test `retrieveBase()` with excess, and no excess for PoolYearnVault.sol
- [x] Test `retrieveShares()` with excess, and no excess for PoolYearnVault.sol
- [x] Test `retrieveFYToken()` with excess, and no excess for PoolYearnVault.sol