### PR TITLE
fix: mature burn fork tests

### DIFF
--- a/src/test/pools/Euler/fork/dai/MintBurn.t.sol
+++ b/src/test/pools/Euler/fork/dai/MintBurn.t.sol
@@ -166,12 +166,15 @@ contract MatureBurn_WithLiquidityEulerDAIFork is EulerDAIForkWithLiquidity {
         uint256 lpTokensIn = poolBalBefore;
 
         (uint104 sharesReservesBefore, uint104 fyTokenReservesBefore, , ) = pool.getCache();
-        uint256 expectedSharesOut = (lpTokensIn * sharesReservesBefore) / pool.totalSupply();
-        uint256 expectedAssetsOut = pool.unwrapPreview(expectedSharesOut);
+
+        // after maturity
+        vm.warp(pool.maturity());
+
         // fyTokenOut = lpTokensIn * realFyTokenReserves / totalSupply
         uint256 expectedFyTokenOut = (lpTokensIn * (fyTokenReservesBefore - pool.totalSupply())) / pool.totalSupply();
+        uint256 expectedSharesOut = (lpTokensIn * sharesReservesBefore) / pool.totalSupply();
+        uint256 expectedAssetsOut = pool.unwrapPreview(expectedSharesOut);
 
-        vm.warp(pool.maturity());
         vm.startPrank(alice);
 
         pool.transfer(address(pool), lpTokensIn);

--- a/src/test/pools/Euler/fork/dai/MintBurn.t.sol
+++ b/src/test/pools/Euler/fork/dai/MintBurn.t.sol
@@ -156,8 +156,8 @@ contract Burn__WithLiquidityEulerDAIFork is EulerDAIForkWithLiquidity {
     }
 }
 
-contract MatureBurn_WithLiquidityEulerDAIFork is EulerDAIFork {
-    function testForkUnit_Euler_matureBurn01() public {
+contract MatureBurn_WithLiquidityEulerDAIFork is EulerDAIForkWithLiquidity {
+    function testForkUnit_Euler_matureBurnDAI01() public {
         console.log("burns after maturity");
 
         uint256 assetBalBefore = asset.balanceOf(alice);
@@ -190,7 +190,7 @@ contract MatureBurn_WithLiquidityEulerDAIFork is EulerDAIFork {
     }
 }
 
-contract MintWithBase__WithLiquidityEulerDAIFork is EulerDAIFork {
+contract MintWithBase__WithLiquidityEulerDAIFork is EulerDAIForkWithLiquidity {
     function testForkUnit_Euler_mintWithBaseDAI01() public {
         console.log("does not mintWithBase when mature");
 

--- a/src/test/pools/Euler/fork/usdc/MintBurn.t.sol
+++ b/src/test/pools/Euler/fork/usdc/MintBurn.t.sol
@@ -166,12 +166,15 @@ contract MatureBurn_WithLiquidityEulerUSDCFork is EulerUSDCForkSkewedReserves {
         uint256 lpTokensIn = poolBalBefore;
 
         (uint104 sharesReservesBefore, uint104 fyTokenReservesBefore, , ) = pool.getCache();
-        uint256 expectedSharesOut = (lpTokensIn * sharesReservesBefore) / pool.totalSupply();
-        uint256 expectedAssetsOut = pool.unwrapPreview(expectedSharesOut);
+
+        // after maturity
+        vm.warp(pool.maturity());
+
         // fyTokenOut = lpTokensIn * realFyTokenReserves / totalSupply
         uint256 expectedFyTokenOut = (lpTokensIn * (fyTokenReservesBefore - pool.totalSupply())) / pool.totalSupply();
+        uint256 expectedSharesOut = (lpTokensIn * sharesReservesBefore) / pool.totalSupply();
+        uint256 expectedAssetsOut = pool.unwrapPreview(expectedSharesOut);
 
-        vm.warp(pool.maturity());
         vm.startPrank(alice);
 
         pool.transfer(address(pool), lpTokensIn);

--- a/src/test/pools/Euler/fork/usdc/MintBurn.t.sol
+++ b/src/test/pools/Euler/fork/usdc/MintBurn.t.sol
@@ -156,8 +156,8 @@ contract Burn__WithLiquidityEulerUSDCFork is EulerUSDCForkWithLiquidity {
     }
 }
 
-contract MatureBurn_WithLiquidityEulerUSDCFork is EulerUSDCFork {
-    function testForkUnit_Euler_matureBurn01() public {
+contract MatureBurn_WithLiquidityEulerUSDCFork is EulerUSDCForkWithLiquidity {
+    function testForkUnit_Euler_matureBurnUSDC01() public {
         console.log("burns after maturity");
 
         uint256 assetBalBefore = asset.balanceOf(alice);

--- a/src/test/pools/Euler/fork/usdc/MintBurn.t.sol
+++ b/src/test/pools/Euler/fork/usdc/MintBurn.t.sol
@@ -156,7 +156,7 @@ contract Burn__WithLiquidityEulerUSDCFork is EulerUSDCForkWithLiquidity {
     }
 }
 
-contract MatureBurn_WithLiquidityEulerUSDCFork is EulerUSDCForkWithLiquidity {
+contract MatureBurn_WithLiquidityEulerUSDCFork is EulerUSDCForkSkewedReserves {
     function testForkUnit_Euler_matureBurnUSDC01() public {
         console.log("burns after maturity");
 


### PR DESCRIPTION
fixes the mature burn fork tests to estimate assets out from burn using proper post-maturity share price (was calling unwrap preview before maturity, which is inaccurate because share price should go up over time {after maturity})