### PR TITLE
Split functions

### DIFF
--- a/src/Pool/Modules/PoolEuler.sol
+++ b/src/Pool/Modules/PoolEuler.sol
@@ -38,7 +38,7 @@ contract PoolEuler is Pool {
         address euler_, // The main Euler contract address
         address eToken_,
         address fyToken_,
-        uint128 ts_,
+        uint256 ts_,
         uint16 g1Fee_
     ) Pool(eToken_, fyToken_, ts_, g1Fee_) {
         // Approve the main Euler contract to take base from the Pool, used on `deposit`.

--- a/src/Pool/Modules/PoolNonTv.sol
+++ b/src/Pool/Modules/PoolNonTv.sol
@@ -30,7 +30,7 @@ contract PoolNonTv is Pool {
     constructor(
         address base_,
         address fyToken_,
-        uint128 ts_,
+        uint256 ts_,
         uint16 g1Fee_
     ) Pool(base_, fyToken_, ts_, g1Fee_) {}
 

--- a/src/Pool/Modules/PoolYearnVault.sol
+++ b/src/Pool/Modules/PoolYearnVault.sol
@@ -37,7 +37,7 @@ contract PoolYearnVault is Pool {
     constructor(
         address sharesToken_,
         address fyToken_,
-        uint128 ts_,
+        uint256 ts_,
         uint16 g1Fee_
     ) Pool(sharesToken_, fyToken_, ts_, g1Fee_) {}
 

--- a/src/Pool/Pool.sol
+++ b/src/Pool/Pool.sol
@@ -1459,7 +1459,7 @@ contract Pool is PoolEvents, IPool, ERC20Permit, AccessControl {
     /// @param amount Amount as standard fp number.
     /// @return product Return standard fp number retaining decimals of provided amount.
     function _mulMu(uint256 amount) internal view returns (uint256 product) {
-        product = mu * amount;
+        product = mu.wmul(amount);
     }
 
     /// Retrieve any shares tokens not accounted for in the cache.

--- a/src/YieldMath.sol
+++ b/src/YieldMath.sol
@@ -71,13 +71,31 @@ library YieldMath {
         uint256 mu
     ) public pure returns (uint128) {
 
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
+        return _fyTokenOutForSharesIn(
+            sharesReserves,
+            fyTokenReserves,
+            sharesIn,
+            _computeA(
+                timeTillMaturity,
+                k.fromFP18(),
+                g.fromFP18()
+            ),
+            c.fromFP18(),
+            mu.fromFP18()
+        );
+    }
+
+    function _fyTokenOutForSharesIn(
+        uint128 sharesReserves, // z
+        uint128 fyTokenReserves, // x
+        uint128 sharesIn, // x == Δz
+        uint128 a,
+        int128 c,
+        int128 mu
+    ) public pure returns (uint128) {
 
         unchecked {
             require(c > 0 && mu > 0, "YieldMath: c and mu must be positive");
-
-            uint128 a = _computeA(timeTillMaturity, k, g);
 
             uint256 sum;
             {
@@ -184,9 +202,13 @@ library YieldMath {
                     sharesReserves,
                     fyTokenReserves,
                     fyTokenIn,
-                    _computeA(timeTillMaturity, k, g),
-                    c,
-                    mu
+                    _computeA(
+                        timeTillMaturity,
+                        k.fromFP18(),
+                        g.fromFP18()
+                    ),
+                    c.fromFP18(),
+                    mu.fromFP18()
                 );
         }
     }
@@ -197,8 +219,8 @@ library YieldMath {
         uint128 fyTokenReserves,
         uint128 fyTokenIn,
         uint128 a,
-        uint256 c,
-        uint256 mu
+        int128 c,
+        int128 mu
     ) private pure returns (uint128) {
         /* https://docs.google.com/spreadsheets/d/14K_McZhlgSXQfi6nFGwDvDh4BmOu6_Hczi_sFreFfOE/
 
@@ -211,9 +233,6 @@ library YieldMath {
             Δz = z -   1/μ   * ( ( (c / μ) * (μz)^(1-t) +  y^(1-t) - (y + x)^(1-t) ) / (c / μ) )^(1 / (1 - t))
 
         */
-
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
 
         unchecked {
             // normalizedSharesReserves = μ * sharesReserves
@@ -294,6 +313,28 @@ library YieldMath {
         uint256 c,
         uint256 mu
     ) public pure returns (uint128) {
+        return _fyTokenInForSharesOut(
+            sharesReserves,
+            fyTokenReserves,
+            sharesOut,
+            _computeA(
+                timeTillMaturity,
+                k.fromFP18(),
+                g.fromFP18()
+            ),
+            c.fromFP18(),
+            mu.fromFP18()
+        );
+    }
+
+    function _fyTokenInForSharesOut(
+        uint128 sharesReserves,
+        uint128 fyTokenReserves,
+        uint128 sharesOut,
+        uint128 a,
+        int128 c,
+        int128 mu
+    ) public pure returns (uint128) {
         /* https://docs.google.com/spreadsheets/d/14K_McZhlgSXQfi6nFGwDvDh4BmOu6_Hczi_sFreFfOE/
 
                 y = fyToken reserves
@@ -306,13 +347,9 @@ library YieldMath {
 
             */
 
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
-
         unchecked {
             require(c > 0 && mu > 0, "YieldMath: c and mu must be positive");
 
-            uint128 a = _computeA(timeTillMaturity, k, g);
             uint256 sum;
             {
                 // normalizedSharesReserves = μ * sharesReserves
@@ -404,9 +441,13 @@ library YieldMath {
                     sharesReserves,
                     fyTokenReserves,
                     fyTokenOut,
-                    _computeA(timeTillMaturity, k, g),
-                    c,
-                    mu
+                    _computeA(
+                        timeTillMaturity,
+                        k.fromFP18(),
+                        g.fromFP18()
+                    ),
+                    c.fromFP18(),
+                    mu.fromFP18()
                 );
         }
     }
@@ -417,8 +458,8 @@ library YieldMath {
         uint128 fyTokenReserves,
         uint128 fyTokenOut,
         uint128 a,
-        uint256 c,
-        uint256 mu
+        int128 c,
+        int128 mu
     ) private pure returns (uint128) {
         /* https://docs.google.com/spreadsheets/d/14K_McZhlgSXQfi6nFGwDvDh4BmOu6_Hczi_sFreFfOE/
 
@@ -431,9 +472,6 @@ library YieldMath {
         Δz = 1/μ * (( c/μ * μz^(1-t) +  y^(1-t) - (y - x)^(1-t)) / (c/μ) )^(1 / (1 - t)) - z
 
         */
-
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
 
         unchecked {
             // normalizedSharesReserves = μ * sharesReserves
@@ -487,6 +525,26 @@ library YieldMath {
         uint256 c,
         uint256 mu
     ) public pure returns (uint128 fyTokenIn) {
+        return _maxFYTokenIn(
+            sharesReserves,
+            fyTokenReserves,
+            _computeA(
+                timeTillMaturity,
+                k.fromFP18(),
+                g.fromFP18()
+            ),
+            c.fromFP18(),
+            mu.fromFP18()
+        );
+    }
+
+    function _maxFYTokenIn(
+        uint128 sharesReserves,
+        uint128 fyTokenReserves,
+        uint128 a,
+        int128 c,
+        int128 mu
+    ) public pure returns (uint128 fyTokenIn) {
         /* https://docs.google.com/spreadsheets/d/14K_McZhlgSXQfi6nFGwDvDh4BmOu6_Hczi_sFreFfOE/
 
                 Y = fyToken reserves
@@ -499,13 +557,9 @@ library YieldMath {
 
             */
 
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
-
         unchecked {
             require(c > 0 && mu > 0, "YieldMath: c and mu must be positive");
 
-            uint128 a = _computeA(timeTillMaturity, k, g);
             uint256 sum;
             {
                 // normalizedSharesReserves = μ * sharesReserves
@@ -564,13 +618,30 @@ library YieldMath {
         uint256 mu
     ) public pure returns (uint128 fyTokenOut) {
 
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
+        return _maxFYTokenOut(
+            sharesReserves,
+            fyTokenReserves,
+            _computeA(
+                timeTillMaturity,
+                k.fromFP18(),
+                g.fromFP18()
+            ),
+            c.fromFP18(),
+            mu.fromFP18()
+        );
+    }
+
+    /// @dev Splitting maxFYTokenOut in two functions to avoid Stack Too Deep errors
+    function _maxFYTokenOut(
+        uint128 sharesReserves,
+        uint128 fyTokenReserves,
+        uint128 a,
+        int128 c,
+        int128 mu
+    ) public pure returns (uint128 fyTokenOut) {
 
         unchecked {
             require(c > 0 && mu > 0, "YieldMath: c and mu must be positive");
-
-            uint128 a = _computeA(timeTillMaturity, k, g);
 
             /*
                 y = maxFyTokenOut
@@ -623,13 +694,30 @@ library YieldMath {
         uint256 mu
     ) public pure returns (uint128 sharesIn) {
 
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
+        return _maxSharesIn(
+            sharesReserves,
+            fyTokenReserves,
+            _computeA(
+                timeTillMaturity,
+                k.fromFP18(),
+                g.fromFP18()
+            ),
+            c.fromFP18(),
+            mu.fromFP18()
+        );
+    }
+
+    /// Splitting maxSharesIn into two functions to avoid stack too deep error
+    function _maxSharesIn(
+        uint128 sharesReserves, // z
+        uint128 fyTokenReserves, // x
+        uint128 a,
+        int128 c,
+        int128 mu
+    ) public pure returns (uint128 sharesIn) {
 
         unchecked {
             require(c > 0 && mu > 0, "YieldMath: c and mu must be positive");
-
-            uint128 a = _computeA(timeTillMaturity, k, g);
 
             /*
                 y = maxSharesIn_
@@ -699,9 +787,19 @@ library YieldMath {
         uint256 mu
     ) public pure returns (uint128 result) {
         if (totalSupply == 0) return 0;
-        uint128 a = _computeA(timeTillMaturity, k, g);
 
-        result = _invariant(sharesReserves, fyTokenReserves, totalSupply, a, c, mu);
+        result = _invariant(
+            sharesReserves,
+            fyTokenReserves,
+            totalSupply,
+            _computeA(
+                timeTillMaturity,
+                k.fromFP18(),
+                g.fromFP18()
+            ),
+            c.fromFP18(),
+            mu.fromFP18()
+        );
     }
 
     /// @param sharesReserves yield bearing vault shares reserve amount
@@ -716,13 +814,9 @@ library YieldMath {
         uint128 fyTokenReserves, // x
         uint256 totalSupply, // s
         uint128 a,
-        uint256 c,
-        uint256 mu
+        int128 c,
+        int128 mu
     ) internal pure returns (uint128 result) {
-
-        int128 a = a.fromFP18();
-        int128 c = c.fromFP18();
-        int128 mu = mu.fromFP18();
 
         unchecked {
             require(c > 0 && mu > 0, "YieldMath: c and mu must be positive");
@@ -751,7 +845,7 @@ library YieldMath {
             int128 denominator = c.div(mu).add(int128(ONE));
 
             // topTerm = c/μ * (numerator / denominator) ** (1/a)
-            int128 topTerm = c.div(mu).mul((numerator.div(denominator)).pow(int128(ONE).div(a)));
+            int128 topTerm = c.div(mu).mul((numerator.div(denominator)).pow(int128(ONE).div(a.i128())));
 
             result = uint128((topTerm.mulu(WAD) * WAD) / totalSupply);
         }
@@ -762,12 +856,9 @@ library YieldMath {
 
     function _computeA(
         uint128 timeTillMaturity,
-        uint256 k,
-        uint256 g
+        int128 k,
+        int128 g
     ) private pure returns (uint128) {
-
-        int128 k = k.fromFP18();
-        int128 g = g.fromFP18();
 
         // t = k * timeTillMaturity
         int128 t = k.mul(timeTillMaturity.fromUInt());

--- a/src/test/YieldMath.t.sol
+++ b/src/test/YieldMath.t.sol
@@ -100,12 +100,12 @@ contract YieldMathTest is Test {
     constructor() {
         // The Desmos formulas use this * 10 at the end for tenths of a second.  Pool.sol does not.
         uint256 invK = 25 * 365 * 24 * 60 * 60 * 10;
-        k = uint256(1).fromUInt().div(invK.fromUInt()).u128();
+        k = uint256(1e18) / invK;
 
-        g1 = gNumerator.fromUInt().div(gDenominator.fromUInt()).u128();
-        g2 = gDenominator.fromUInt().div(gNumerator.fromUInt()).u128();
-        c = cNumerator.fromUInt().div(cDenominator.fromUInt()).u128();
-        mu = muNumerator.fromUInt().div(muDenominator.fromUInt()).u128();
+        g1 = gNumerator * 1e18 / gDenominator;
+        g2 = gDenominator * 1e18 / gNumerator;
+        c = cNumerator * 1e18 / cDenominator;
+        mu = muNumerator * 1e18 / muDenominator;
     }
 
     function percentOrMinimum(
@@ -169,7 +169,7 @@ contract YieldMathTest is Test {
             k,
             g1,
             c,
-            type(int128).max.u128()
+            uint128(type(int128).max / 2**64 * 1e18)
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Rate overflow (za)"));
@@ -180,8 +180,8 @@ contract YieldMathTest is Test {
             timeTillMaturity,
             k,
             g1,
-            type(int128).max.u128(),
-            0x10000000000000000
+            uint128(type(int128).max / 2**64 * 1e18),
+            1e18
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Rate overflow (nsi)"));
@@ -272,7 +272,7 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -282,7 +282,7 @@ contract YieldMathTest is Test {
             result,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -299,7 +299,7 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -309,7 +309,7 @@ contract YieldMathTest is Test {
             sharesAmount,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -328,7 +328,7 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             0,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         ) / 1e18;
@@ -347,9 +347,9 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             25 * 365 * 24 * 60 * 60 * 10 - 10,
             k,
-            YieldMath.ONE, // set fees to 0
-            YieldMath.ONE, // set c to 1
-            YieldMath.ONE //  set mu to 1
+            1e18, // set fees to 0
+            1e18, // set c to 1
+            1e18 //  set mu to 1
         );
         uint256 oldK = uint256(fyTokenReserves) * uint256(sharesReserves);
 
@@ -457,7 +457,7 @@ contract YieldMathTest is Test {
             k,
             g1,
             c,
-            type(int128).max.u128()
+            uint128(type(int128).max / 2**64 * 1e18)
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Rate overflow (za)"));
@@ -468,8 +468,8 @@ contract YieldMathTest is Test {
             timeTillMaturity,
             k,
             g1,
-            type(int128).max.u128(),
-            0x10000000000000000
+            uint128(type(int128).max / 2**64 * 1e18),
+            1e18
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Underflow (yxa)"));
@@ -550,7 +550,7 @@ contract YieldMathTest is Test {
             fyTokenAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -560,7 +560,7 @@ contract YieldMathTest is Test {
             result,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -577,7 +577,7 @@ contract YieldMathTest is Test {
             fyTokenAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -587,7 +587,7 @@ contract YieldMathTest is Test {
             fyTokenAmount,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -604,7 +604,7 @@ contract YieldMathTest is Test {
             fyTokenAmount, // x or ΔZ
             0,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -670,7 +670,7 @@ contract YieldMathTest is Test {
             k,
             g1,
             c,
-            type(int128).max.u128()
+            uint128(type(int128).max / 2**64 * 1e18)
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Rate overflow (za)"));
@@ -681,8 +681,8 @@ contract YieldMathTest is Test {
             timeTillMaturity,
             k,
             g1,
-            type(int128).max.u128(),
-            0x10000000000000000
+            uint128(type(int128).max / 2**64 * 1e18),
+            1e18
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Rate overflow (yxa)"));
@@ -764,7 +764,7 @@ contract YieldMathTest is Test {
             fyTokenAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -774,7 +774,7 @@ contract YieldMathTest is Test {
             result,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -792,7 +792,7 @@ contract YieldMathTest is Test {
             fyTokenAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -802,7 +802,7 @@ contract YieldMathTest is Test {
             fyTokenAmount,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -819,7 +819,7 @@ contract YieldMathTest is Test {
             fyTokenAmount, // x or ΔZ
             0,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -884,7 +884,7 @@ contract YieldMathTest is Test {
             k,
             g1,
             c,
-            type(int128).max.u128()
+            uint128(type(int128).max / 2**64 * 1e18)
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Rate overflow (za)"));
@@ -895,8 +895,8 @@ contract YieldMathTest is Test {
             timeTillMaturity,
             k,
             g1,
-            type(int128).max.u128(),
-            0x10000000000000000
+            uint128(type(int128).max / 2**64 * 1e18),
+            1e18
         ) / 1e18;
 
         vm.expectRevert(bytes("YieldMath: Rate overflow (nso)"));
@@ -1000,7 +1000,7 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -1010,7 +1010,7 @@ contract YieldMathTest is Test {
             result,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -1025,7 +1025,7 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -1035,7 +1035,7 @@ contract YieldMathTest is Test {
             sharesAmount,
             timeTillMaturity,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -1055,7 +1055,7 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             0,
             k,
-            YieldMath.ONE,
+            1e18,
             c,
             mu
         );
@@ -1072,9 +1072,9 @@ contract YieldMathTest is Test {
             sharesAmount, // x or ΔZ
             25 * 365 * 24 * 60 * 60 * 10 - 10,
             k,
-            YieldMath.ONE, // set fees to 0
-            YieldMath.ONE, // set c to 1
-            YieldMath.ONE //  set mu to 1
+            1e18, // set fees to 0
+            1e18, // set c to 1
+            1e18 //  set mu to 1
         );
         uint256 oldK = uint256(fyTokenReserves) * uint256(sharesReserves);
 

--- a/src/test/mocks/SyncablePool.sol
+++ b/src/test/mocks/SyncablePool.sol
@@ -9,7 +9,7 @@ contract SyncablePool is Pool, ISyncablePool {
     constructor(
         address shares_,
         address fyToken_,
-        uint128 ts_,
+        uint256 ts_,
         uint16 g1Fee_
     ) Pool(shares_, fyToken_, ts_, g1Fee_) {}
 

--- a/src/test/mocks/SyncablePoolEuler.sol
+++ b/src/test/mocks/SyncablePoolEuler.sol
@@ -10,7 +10,7 @@ contract SyncablePoolEuler is PoolEuler, ISyncablePool {
         address euler_, // The main Euler contract address
         address shares_,
         address fyToken_,
-        uint128 ts_,
+        uint256 ts_,
         uint16 g1Fee_
     ) PoolEuler(euler_, shares_, fyToken_, ts_, g1Fee_) {}
 

--- a/src/test/mocks/SyncablePoolNonTv.sol
+++ b/src/test/mocks/SyncablePoolNonTv.sol
@@ -9,7 +9,7 @@ contract SyncablePoolNonTv is PoolNonTv, ISyncablePool {
     constructor(
         address shares_,
         address fyToken_,
-        uint128 ts_,
+        uint256 ts_,
         uint16 g1Fee_
     ) PoolNonTv(shares_, fyToken_, ts_, g1Fee_) {}
 

--- a/src/test/mocks/SyncablePoolYearnVault.sol
+++ b/src/test/mocks/SyncablePoolYearnVault.sol
@@ -9,7 +9,7 @@ contract SyncablePoolYearnVault is PoolYearnVault, ISyncablePool {
     constructor(
         address shares_,
         address fyToken_,
-        uint128 ts_,
+        uint256 ts_,
         uint16 g1Fee_
     ) PoolYearnVault(shares_, fyToken_, ts_, g1Fee_) {}
 

--- a/src/test/shared/TestCore.sol
+++ b/src/test/shared/TestCore.sol
@@ -41,21 +41,21 @@ abstract contract TestCore is PoolEvents, Test {
 
     uint32 public maturity = uint32(block.timestamp + THREE_MONTHS);
 
-    uint128 public ts;
+    uint256 public ts;
 
-    uint128 immutable k;
+    uint256 immutable k;
 
     uint16 public constant g1Fee = 9500;
     uint16 public constant g1Denominator = 10000;
-    uint128 public g1; // g to use when selling shares to pool
-    uint128 public g2; // g to use when selling fyTokens to pool
+    uint256 public g1; // g to use when selling shares to pool
+    uint256 public g2; // g to use when selling fyTokens to pool
 
     uint256 public constant cNumerator = 11;
     uint256 public constant cDenominator = 10;
 
     uint256 public constant muNumerator = 105;
     uint256 public constant muDenominator = 100;
-    uint128 public mu;
+    uint256 public mu;
 
     string public assetName;
     string public assetSymbol;

--- a/src/test/shared/ZeroState.sol
+++ b/src/test/shared/ZeroState.sol
@@ -59,7 +59,7 @@ abstract contract ZeroState is TestCore {
 
 
     constructor(ZeroStateParams memory params) {
-        ts = ONE.i128().div(uint256(25 * 365 * 24 * 60 * 60 * 10).fromUInt()).u128();
+        ts = 1e18 / uint256(25 * 365 * 24 * 60 * 60 * 10);
 
         // Set base asset state variables.
         assetName = params.assetName;


### PR DESCRIPTION
To get around the stack to deep errors, you can split all functions in an outer and inner functions.

The outer does all conversions and calculates `a`.
The inner has all the math logic.

With this, I can compile the library normally. I also converted the 64.64 parameters in the YieldMath.t.sol constructor to fp18.

However, lots of failing tests :(