### PR TITLE
fix(solidity): failed assertion

### DIFF
--- a/src/Math64x64.sol
+++ b/src/Math64x64.sol
@@ -620,9 +620,7 @@ library Math64x64 {
                 if (xl < lo) xh -= 1;
                 xl -= lo; // We rely on overflow behavior here
 
-                assert(xh == hi >> 128);
-
-                result += xl / y;
+                result += xh == hi >> 128 ? xl / y : 1;
             }
 
             require(result <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);


### PR DESCRIPTION
See updated fix from https://github.com/abdk-consulting/abdk-libraries-solidity/commit/5e1e7c11b35f8313d3f7ce11c1b86320d7c0b554


---


https://github.com/abdk-consulting/abdk-libraries-solidity/commit/5e1e7c11b35f8313d3f7ce11c1b86320d7c0b554.patch

From 5e1e7c11b35f8313d3f7ce11c1b86320d7c0b554 Mon Sep 17 00:00:00 2001
Mikhail Vladimirov <mikhail.vladimirov@gmail.com>


---


 ABDKMath64x64.sol | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)

diff --git a/ABDKMath64x64.sol b/ABDKMath64x64.sol index 8b53809..2cbe46a 100644
--- a/ABDKMath64x64.sol
+++ b/ABDKMath64x64.sol
```diff
@@ -707,9 +707,7 @@ library ABDKMath64x64 {
         if (xl < lo) xh -= 1;
         xl -= lo; // We rely on overflow behavior here
 
-        assert (xh == hi >> 128);
-
-        result += xl / y;
+        result += xh == hi >> 128 ? xl / y : 1;
       }
 
       require (result <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
```